### PR TITLE
FIX: Use correct method in jsonML example

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -23,7 +23,7 @@ bc. console.log( textile( "I am using __textile__." ) );
 
 You can also get to the syntax tree, which uses "JsonML":http://www.jsonml.org/.
 
-bc. var jsonml = textile.parse( text );
+bc. var jsonml = textile.jsonml( text );
 console.log( jsonml );
 
 


### PR DESCRIPTION
Hi, 

there's a little mistake in the Readme regarding the jsonML-example.

Thanks for the project!

Stephan